### PR TITLE
Tmdb: Add Tmdb API service test

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "flow-bin": "^0.74.0",
     "husky": "^1.0.0-rc.8",
     "prettier": "1.13.5",
-    "redux-devtools-extension": "^2.13.2"
+    "redux-devtools-extension": "^2.13.2",
+    "url-search-params-polyfill": "^4.0.0"
   }
 }

--- a/src/utils/Tmdb.js
+++ b/src/utils/Tmdb.js
@@ -216,7 +216,7 @@ class Tmdb {
    * @param {Object} [searchParams] -
    *        {key0:value0, key1:value1}, will transform into ?key0=value0&key1=value1,
    *        keys and values are URL encoded for safety and consistency
-   * @returns {string}
+   * @returns {URL}
    * @private
    */
   _makeGetUrl(

--- a/src/utils/Tmdb.test.js
+++ b/src/utils/Tmdb.test.js
@@ -1,0 +1,11 @@
+import Tmdb from './Tmdb';
+import 'url-search-params-polyfill';
+
+it('passes test with URLSearchParams', () => {
+  expect(Tmdb._makeGetUrl('movie', ['list'], { lang: 'en' })).toEqual(
+    new URL(
+      'https://api.themoviedb.org/3/movie/list?lang=en&api_key=' +
+        Tmdb.apiConfig.key
+    )
+  );
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -6297,7 +6297,7 @@ reduce-function-call@^1.0.1:
   dependencies:
     balanced-match "^0.4.2"
 
-redux-devtools-extension@^2.13.5:
+redux-devtools-extension@^2.13.2:
   version "2.13.5"
   resolved "https://registry.yarnpkg.com/redux-devtools-extension/-/redux-devtools-extension-2.13.5.tgz#3ff34f7227acfeef3964194f5f7fc2765e5c5a39"
 
@@ -7438,6 +7438,10 @@ url-parse@^1.1.8, url-parse@~1.4.0:
   dependencies:
     querystringify "^2.0.0"
     requires-port "^1.0.0"
+
+url-search-params-polyfill@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/url-search-params-polyfill/-/url-search-params-polyfill-4.0.0.tgz#9f51d499c500d84b43d940677f3f7ac756410167"
 
 url@^0.11.0:
   version "0.11.0"


### PR DESCRIPTION
CHANGELOG
 * Added
   - `url-search-params-polyfill` dev dependency to be used in tests under jest env
   - `Tmdb.test.js` to perform basic Tmdb service test against employed `URLSearchParams` polyfill
 * Changed
   - `Tmdb.js::_makeGetUrl()` JSDoc `@returns` spec as method returns `{URL}`